### PR TITLE
Ensure null is sent to server when complex attr (array, or object etc) is cleared

### DIFF
--- a/addon/transforms/complex-attr-array.js
+++ b/addon/transforms/complex-attr-array.js
@@ -1,5 +1,4 @@
-import {isBlank} from '@ember/utils';
-import {A} from '@ember/array';
+import {A, isArray} from '@ember/array';
 import ComplexAttrTransform from '@rigo/ember-data-complex-attrs/transforms/complex-attr';
 
 export default ComplexAttrTransform.extend({
@@ -8,8 +7,8 @@ export default ComplexAttrTransform.extend({
    * @override
    */
   deserialize(serialized, {type}) {
-    if (isBlank(serialized)) {
-      return A();
+    if (!isArray(serialized)) {
+      return;
     }
 
     const ComplexAttrFactory = this.factoryForType(type);
@@ -24,8 +23,8 @@ export default ComplexAttrTransform.extend({
    * @override
    */
   serialize(deserialized, {type}) {
-    if (isBlank(deserialized)) {
-      return [];
+    if (!isArray(deserialized)) {
+      return null;
     }
 
     const attributeMetadata = this.attributesMetadataForType(type);

--- a/addon/transforms/complex-attr-array.js
+++ b/addon/transforms/complex-attr-array.js
@@ -8,7 +8,7 @@ export default ComplexAttrTransform.extend({
    */
   deserialize(serialized, {type}) {
     if (!isArray(serialized)) {
-      return;
+      return A();
     }
 
     const ComplexAttrFactory = this.factoryForType(type);
@@ -24,7 +24,7 @@ export default ComplexAttrTransform.extend({
    */
   serialize(deserialized, {type}) {
     if (!isArray(deserialized)) {
-      return null;
+      return [];
     }
 
     const attributeMetadata = this.attributesMetadataForType(type);

--- a/addon/transforms/complex-attr-object.js
+++ b/addon/transforms/complex-attr-object.js
@@ -21,7 +21,7 @@ export default ComplexAttrTransform.extend({
    */
   serialize(deserialized, {type}) {
     if (isBlank(deserialized)) {
-      return;
+      return null;
     }
 
     return this.serializeAttributes(this.attributesMetadataForType(type), deserialized);

--- a/tests/unit/transforms/complex-attr-array-test.js
+++ b/tests/unit/transforms/complex-attr-array-test.js
@@ -34,7 +34,7 @@ test('#deserialize handles blank serialized value', function (assert) {
 test('#deserialize handles undefined/null serialized value', function (assert) {
   let transform = this.subject();
 
-  assert.equal(transform.deserialize(undefined, {type: 'foo'}), null);
+  assert.deepEqual(transform.deserialize(undefined, {type: 'foo'}), []);
 });
 
 test('#deserialize works', function (assert) {
@@ -102,7 +102,7 @@ test('#serialize handles blank deserialized value', function (assert) {
 
   let transform = this.subject();
 
-  assert.deepEqual(transform.serialize(undefined, {type: 'foo'}), null);
+  assert.deepEqual(transform.serialize(undefined, {type: 'foo'}), []);
 });
 
 test('#serialize works', function (assert) {

--- a/tests/unit/transforms/complex-attr-array-test.js
+++ b/tests/unit/transforms/complex-attr-array-test.js
@@ -28,7 +28,13 @@ test('it exists', function (assert) {
 test('#deserialize handles blank serialized value', function (assert) {
   let transform = this.subject();
 
-  assert.deepEqual(transform.deserialize(undefined, {type: 'foo'}), []);
+  assert.deepEqual(transform.deserialize([], {type: 'foo'}), []);
+});
+
+test('#deserialize handles undefined/null serialized value', function (assert) {
+  let transform = this.subject();
+
+  assert.equal(transform.deserialize(undefined, {type: 'foo'}), null);
 });
 
 test('#deserialize works', function (assert) {
@@ -96,7 +102,7 @@ test('#serialize handles blank deserialized value', function (assert) {
 
   let transform = this.subject();
 
-  assert.deepEqual(transform.serialize(undefined, {type: 'foo'}), []);
+  assert.deepEqual(transform.serialize(undefined, {type: 'foo'}), null);
 });
 
 test('#serialize works', function (assert) {

--- a/tests/unit/transforms/complex-attr-object-test.js
+++ b/tests/unit/transforms/complex-attr-object-test.js
@@ -25,6 +25,12 @@ moduleFor('transform:complex-attr-object', 'Unit | Transform | complex attr obje
   }
 });
 
+test('#deserialize handles blank serialized value', function (assert) {
+  let transform = this.subject();
+
+  assert.equal(transform.deserialize(undefined, {type: 'foo'}), undefined);
+});
+
 test('#deserialize works', function (assert) {
   assert.expect(12);
 


### PR DESCRIPTION
Makes two updates:

1 - Ensures that complex-attr-array is always serialized/deserialized to an array in the case where the input/output values are blank
2 - Ensures that complex-attr-object seriailzes to null when blank and deserialized to undefined when the input value is blank.