### PR TITLE
Feature/implement copyable on complex attr

### DIFF
--- a/addon/models/complex-attrs/complex-attr.js
+++ b/addon/models/complex-attrs/complex-attr.js
@@ -1,11 +1,14 @@
+import Ember from 'ember';
 import EmberObject from '@ember/object';
 import {uuid} from 'ember-cli-uuid';
-import attr from '@rigo/ember-data-complex-attrs/attr'
+import attr from '@rigo/ember-data-complex-attrs/attr';
 
-const ComplexAttr = EmberObject.extend({
+const ComplexAttr = EmberObject.extend(Ember.Copyable, {
   id: attr('string', {
     defaultValue: () => uuid()
-  })
+  }),
+
+  copy() {}
 });
 
 export default ComplexAttr;

--- a/addon/models/complex-attrs/complex-attr.js
+++ b/addon/models/complex-attrs/complex-attr.js
@@ -30,6 +30,11 @@ ComplexAttr.reopen({
     const attributesMetadata = klass.attributesMetadata();
 
     const properties = Object.keys(attributesMetadata).reduce((result, attributeName) => {
+      // do not copy id!
+      if(attributeName === 'id') {
+        return result;
+      }
+
       result[attributeName] = deep ? copy(this.get(attributeName), true) : this.get(attributeName);
 
       return result;

--- a/addon/models/complex-attrs/complex-attr.js
+++ b/addon/models/complex-attrs/complex-attr.js
@@ -11,4 +11,18 @@ const ComplexAttr = EmberObject.extend(Ember.Copyable, {
   copy() {}
 });
 
+ComplexAttr.reopenClass({
+  attributesMetadata() {
+    const attributeMetadata = {};
+
+    this.eachComputedProperty((name, meta) => {
+      if (meta.isComplexAttribute) {
+        attributeMetadata[name] = meta;
+      }
+    });
+
+    return attributeMetadata;
+  },
+});
+
 export default ComplexAttr;

--- a/addon/models/complex-attrs/complex-attr.js
+++ b/addon/models/complex-attrs/complex-attr.js
@@ -35,7 +35,7 @@ ComplexAttr.reopen({
         return result;
       }
 
-      result[attributeName] = deep ? copy(this.get(attributeName), true) : this.get(attributeName);
+      result[attributeName] = deep ? copy(this.get(attributeName), deep) : this.get(attributeName);
 
       return result;
     }, {});

--- a/addon/models/complex-attrs/complex-attr.js
+++ b/addon/models/complex-attrs/complex-attr.js
@@ -8,6 +8,7 @@ const ComplexAttr = EmberObject.extend(Ember.Copyable);
 
 ComplexAttr.reopenClass({
   attributesMetadata() {
+    // TODO: Should we cache this value?
     const attributeMetadata = {};
 
     this.eachComputedProperty((name, meta) => {

--- a/addon/transforms/complex-attr-array.js
+++ b/addon/transforms/complex-attr-array.js
@@ -13,7 +13,8 @@ export default ComplexAttrTransform.extend({
     }
 
     const ComplexAttrFactory = this.factoryForType(type);
-    const attributeMetadata = this.attributesMetadataForType(type);
+    const ComplexAttrRegistration = this.registrationForType(type);
+    const attributeMetadata = ComplexAttrRegistration.attributesMetadata();
 
     return A(serialized.map((attributes) => {
       return ComplexAttrFactory.create(this.deserializeAttributes(attributeMetadata, attributes));
@@ -28,7 +29,8 @@ export default ComplexAttrTransform.extend({
       return [];
     }
 
-    const attributeMetadata = this.attributesMetadataForType(type);
+    const ComplexAttrRegistration = this.registrationForType(type);
+    const attributeMetadata = ComplexAttrRegistration.attributesMetadata();
 
     return deserialized.map((attributes) => this.serializeAttributes(attributeMetadata, attributes));
   }

--- a/addon/transforms/complex-attr-object.js
+++ b/addon/transforms/complex-attr-object.js
@@ -12,8 +12,9 @@ export default ComplexAttrTransform.extend({
     }
 
     const ComplexAttrFactory = this.factoryForType(type);
+    const ComplexAttrRegistration = this.registrationForType(type);
 
-    return ComplexAttrFactory.create(this.deserializeAttributes(this.attributesMetadataForType(type), serialized));
+    return ComplexAttrFactory.create(this.deserializeAttributes(ComplexAttrRegistration.attributesMetadata(), serialized));
   },
 
   /**
@@ -23,7 +24,9 @@ export default ComplexAttrTransform.extend({
     if (isBlank(deserialized)) {
       return;
     }
+    const ComplexAttrRegistration = this.registrationForType(type);
+    const attributeMetadata = ComplexAttrRegistration.attributesMetadata();
 
-    return this.serializeAttributes(this.attributesMetadataForType(type), deserialized);
+    return this.serializeAttributes(attributeMetadata, deserialized);
   }
 });

--- a/addon/transforms/complex-attr.js
+++ b/addon/transforms/complex-attr.js
@@ -13,24 +13,6 @@ const nullTransform = {
 export default DS.Transform.extend({
 
   /**
-   * @method attributeMetadataForType
-   * @param {String} type ComplexAttr type to fetch metadata for
-   * @returns {{}} The metadata values for the given ComplexAttr type
-   */
-  attributesMetadataForType(type) {
-    const ComplexAttrRegistration = this.registrationForType(type);
-
-    const attributeMetadata = {};
-    ComplexAttrRegistration.eachComputedProperty((name, meta) => {
-      if (meta.isComplexAttribute) {
-        attributeMetadata[name] = meta;
-      }
-    });
-
-    return attributeMetadata;
-  },
-
-  /**
    * @method serializeAttributes
    * @param attributes
    * @param attributesMetadata

--- a/tests/unit/models/models/complex-attrs/complex-attr-test.js
+++ b/tests/unit/models/models/complex-attrs/complex-attr-test.js
@@ -1,7 +1,6 @@
 import {module, test} from 'ember-qunit';
 import ComplexAttr from '@rigo/ember-data-complex-attrs/models/complex-attrs/complex-attr';
 import attr from '@rigo/ember-data-complex-attrs/attr';
-import {copy} from '@ember/object/internals';
 import {A} from '@ember/array'
 
 let NestableComplexAttr = ComplexAttr.extend({
@@ -41,7 +40,7 @@ test('implements copyable (shallow)', function (assert) {
     nestedComplexAttr
   });
 
-  const copiedComplexAttr = copy(someComplexAttr);
+  const copiedComplexAttr = someComplexAttr.copy();
 
   assert.ok(copiedComplexAttr instanceof SomeComplexAttr, 'clone should be of correct type');
   assert.notEqual(copiedComplexAttr, someComplexAttr, 'clone should be a new instance');
@@ -71,7 +70,7 @@ test('implements copyable (deep)', function (assert) {
     nestedComplexAttr
   });
 
-  const copiedComplexAttr = copy(someComplexAttr, true);
+  const copiedComplexAttr = someComplexAttr.copy(true);
 
   assert.ok(copiedComplexAttr instanceof SomeComplexAttr, 'clone should be of correct type');
   assert.notEqual(copiedComplexAttr, someComplexAttr, 'clone should be a new instance');

--- a/tests/unit/models/models/complex-attrs/complex-attr-test.js
+++ b/tests/unit/models/models/complex-attrs/complex-attr-test.js
@@ -46,7 +46,7 @@ test('implements copyable (shallow)', function (assert) {
   assert.ok(copiedComplexAttr instanceof SomeComplexAttr, 'clone should be of correct type');
   assert.notEqual(copiedComplexAttr, someComplexAttr, 'clone should be a new instance');
 
-  assert.strictEqual(someComplexAttr.get('id'), copiedComplexAttr.get('id'), 'should copy id');
+  assert.notEqual(someComplexAttr.get('id'), copiedComplexAttr.get('id'), 'should not copy id');
   assert.strictEqual(someComplexAttr.get('foo'), copiedComplexAttr.get('foo'));
   assert.strictEqual(someComplexAttr.get('bar'), copiedComplexAttr.get('bar'));
   assert.equal(someComplexAttr.get('baz'), copiedComplexAttr.get('baz'), 'should not deep copy array');
@@ -76,7 +76,7 @@ test('implements copyable (deep)', function (assert) {
   assert.ok(copiedComplexAttr instanceof SomeComplexAttr, 'clone should be of correct type');
   assert.notEqual(copiedComplexAttr, someComplexAttr, 'clone should be a new instance');
 
-  assert.strictEqual(someComplexAttr.get('id'), copiedComplexAttr.get('id'), 'should copy id');
+  assert.notEqual(someComplexAttr.get('id'), copiedComplexAttr.get('id'), 'should not copy id');
   assert.strictEqual(someComplexAttr.get('foo'), copiedComplexAttr.get('foo'));
   assert.strictEqual(someComplexAttr.get('bar'), copiedComplexAttr.get('bar'));
   assert.notEqual(someComplexAttr.get('baz'), copiedComplexAttr.get('baz'), 'should be a deep copy array');

--- a/tests/unit/models/models/complex-attrs/complex-attr-test.js
+++ b/tests/unit/models/models/complex-attrs/complex-attr-test.js
@@ -1,6 +1,20 @@
 import {module, test} from 'ember-qunit';
 import ComplexAttr from '@rigo/ember-data-complex-attrs/models/complex-attrs/complex-attr';
+import attr from '@rigo/ember-data-complex-attrs/attr';
 import {copy} from '@ember/object/internals';
+
+let NestableComplexAttr = ComplexAttr.extend({
+  foo: attr('string')
+});
+
+let SomeComplexAttr = ComplexAttr.extend({
+  foo: attr('string'),
+  bar: attr('number'),
+  baz: attr(),
+  nestedComplexAttr: attr('complex-attr-object', {
+    type: 'nestable-complex-attr'
+  })
+});
 
 module('Unit | Model | models/complex attrs/complex attr', {
   needs: []
@@ -12,10 +26,56 @@ test('it exists', function (assert) {
   assert.ok(!!model);
 });
 
-test('implements copyable', function (assert) {
-  assert.expect(0);
+test('implements copyable (shallow)', function (assert) {
+  assert.expect(7);
 
-  let model = ComplexAttr.create();
+  let nestedComplexAttr = NestableComplexAttr.create({
+    foo: 'bar'
+  });
 
-  copy(model);
+  let someComplexAttr = SomeComplexAttr.create({
+    foo: 'abc',
+    bar: 123,
+    baz: [],
+    nestedComplexAttr
+  });
+
+  const copiedComplexAttr = copy(someComplexAttr);
+
+  assert.ok(copiedComplexAttr instanceof SomeComplexAttr, 'clone should be of correct type');
+  assert.notEqual(copiedComplexAttr, someComplexAttr, 'clone should be a new instance');
+
+  assert.strictEqual(someComplexAttr.get('id'), copiedComplexAttr.get('id'), 'should copy id');
+  assert.strictEqual(someComplexAttr.get('foo'), copiedComplexAttr.get('foo'));
+  assert.strictEqual(someComplexAttr.get('bar'), copiedComplexAttr.get('bar'));
+  assert.equal(someComplexAttr.get('baz'), copiedComplexAttr.get('baz'), 'should not deep copy array');
+  assert.equal(someComplexAttr.get('nestedComplexAttr'), copiedComplexAttr.get('nestedComplexAttr'), 'should not copy nested complex attr');
+});
+
+test('implements copyable (deep)', function (assert) {
+  assert.expect(8);
+
+  let nestedComplexAttr = NestableComplexAttr.create({
+    foo: 'bar'
+  });
+
+  let someComplexAttr = SomeComplexAttr.create({
+    foo: 'abc',
+    bar: 123,
+    baz: [],
+    nestedComplexAttr
+  });
+
+  const copiedComplexAttr = copy(someComplexAttr, true);
+
+  assert.ok(copiedComplexAttr instanceof SomeComplexAttr, 'clone should be of correct type');
+  assert.notEqual(copiedComplexAttr, someComplexAttr, 'clone should be a new instance');
+
+  assert.strictEqual(someComplexAttr.get('id'), copiedComplexAttr.get('id'), 'should copy id');
+  assert.strictEqual(someComplexAttr.get('foo'), copiedComplexAttr.get('foo'));
+  assert.strictEqual(someComplexAttr.get('bar'), copiedComplexAttr.get('bar'));
+  assert.notEqual(someComplexAttr.get('baz'), copiedComplexAttr.get('baz'), 'should be a deep copy array');
+  assert.notEqual(someComplexAttr.get('nestedComplexAttr'), copiedComplexAttr.get('nestedComplexAttr'), 'should be a deep copy nested complex attr');
+
+  assert.strictEqual(someComplexAttr.get('nestedComplexAttr.foo'), copiedComplexAttr.get('nestedComplexAttr.foo'), 'should copy nested properties')
 });

--- a/tests/unit/models/models/complex-attrs/complex-attr-test.js
+++ b/tests/unit/models/models/complex-attrs/complex-attr-test.js
@@ -27,7 +27,7 @@ test('it exists', function (assert) {
 });
 
 test('implements copyable (shallow)', function (assert) {
-  assert.expect(7);
+  assert.expect(8);
 
   let nestedComplexAttr = NestableComplexAttr.create({
     foo: 'bar'
@@ -49,7 +49,11 @@ test('implements copyable (shallow)', function (assert) {
   assert.strictEqual(someComplexAttr.get('foo'), copiedComplexAttr.get('foo'));
   assert.strictEqual(someComplexAttr.get('bar'), copiedComplexAttr.get('bar'));
   assert.equal(someComplexAttr.get('baz'), copiedComplexAttr.get('baz'), 'should not deep copy array');
-  assert.equal(someComplexAttr.get('nestedComplexAttr'), copiedComplexAttr.get('nestedComplexAttr'), 'should not copy nested complex attr');
+
+  const copiedNestedComplexAttr = copiedComplexAttr.get('nestedComplexAttr');
+
+  assert.ok(copiedNestedComplexAttr instanceof NestableComplexAttr, 'clone should be of correct type');
+  assert.equal(nestedComplexAttr, copiedNestedComplexAttr, 'should not deep copy nested complex attr');
 });
 
 test('implements copyable (deep)', function (assert) {
@@ -75,7 +79,9 @@ test('implements copyable (deep)', function (assert) {
   assert.strictEqual(someComplexAttr.get('foo'), copiedComplexAttr.get('foo'));
   assert.strictEqual(someComplexAttr.get('bar'), copiedComplexAttr.get('bar'));
   assert.notEqual(someComplexAttr.get('baz'), copiedComplexAttr.get('baz'), 'should be a deep copy array');
-  assert.notEqual(someComplexAttr.get('nestedComplexAttr'), copiedComplexAttr.get('nestedComplexAttr'), 'should be a deep copy nested complex attr');
 
-  assert.strictEqual(someComplexAttr.get('nestedComplexAttr.foo'), copiedComplexAttr.get('nestedComplexAttr.foo'), 'should copy nested properties')
+  const copiedNestedComplexAttr = copiedComplexAttr.get('nestedComplexAttr');
+
+  assert.notEqual(nestedComplexAttr, copiedNestedComplexAttr, 'should be a deep copy nested complex attr');
+  assert.strictEqual(nestedComplexAttr.get('foo'), copiedNestedComplexAttr.get('foo'), 'should copy nested properties')
 });

--- a/tests/unit/models/models/complex-attrs/complex-attr-test.js
+++ b/tests/unit/models/models/complex-attrs/complex-attr-test.js
@@ -101,7 +101,7 @@ test('copies in array (shallow)', function (assert) {
 });
 
 test('copies in array (deep)', function (assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   const array = [SomeComplexAttr.create({
     foo: 'abc'
@@ -111,4 +111,6 @@ test('copies in array (deep)', function (assert) {
 
   assert.notEqual(array, arrayCopy, 'should be new array');
   assert.notEqual(A(array).get('firstObject'), A(arrayCopy).get('firstObject'), 'should be a new instance');
+
+  assert.equal(array[0].get('foo'), arrayCopy[0].get('foo'), 'foo property should have been copied');
 });

--- a/tests/unit/models/models/complex-attrs/complex-attr-test.js
+++ b/tests/unit/models/models/complex-attrs/complex-attr-test.js
@@ -2,6 +2,7 @@ import {module, test} from 'ember-qunit';
 import ComplexAttr from '@rigo/ember-data-complex-attrs/models/complex-attrs/complex-attr';
 import attr from '@rigo/ember-data-complex-attrs/attr';
 import {copy} from '@ember/object/internals';
+import {A} from '@ember/array'
 
 let NestableComplexAttr = ComplexAttr.extend({
   foo: attr('string')
@@ -84,4 +85,30 @@ test('implements copyable (deep)', function (assert) {
 
   assert.notEqual(nestedComplexAttr, copiedNestedComplexAttr, 'should be a deep copy nested complex attr');
   assert.strictEqual(nestedComplexAttr.get('foo'), copiedNestedComplexAttr.get('foo'), 'should copy nested properties')
+});
+
+test('copies in array (shallow)', function (assert) {
+  assert.expect(2);
+
+  const array = [SomeComplexAttr.create({
+    foo: 'abc'
+  })];
+
+  const arrayCopy = A(array).copy();
+
+  assert.notEqual(array, arrayCopy, 'should be new array');
+  assert.equal(A(array).get('firstObject'), A(arrayCopy).get('firstObject'), 'should be same instance still');
+});
+
+test('copies in array (deep)', function (assert) {
+  assert.expect(2);
+
+  const array = [SomeComplexAttr.create({
+    foo: 'abc'
+  })];
+
+  const arrayCopy = A(array).copy(true);
+
+  assert.notEqual(array, arrayCopy, 'should be new array');
+  assert.notEqual(A(array).get('firstObject'), A(arrayCopy).get('firstObject'), 'should be a new instance');
 });

--- a/tests/unit/models/models/complex-attrs/complex-attr-test.js
+++ b/tests/unit/models/models/complex-attrs/complex-attr-test.js
@@ -1,0 +1,21 @@
+import {module, test} from 'ember-qunit';
+import ComplexAttr from '@rigo/ember-data-complex-attrs/models/complex-attrs/complex-attr';
+import {copy} from '@ember/object/internals';
+
+module('Unit | Model | models/complex attrs/complex attr', {
+  needs: []
+});
+
+test('it exists', function (assert) {
+  let model =  ComplexAttr.create();
+
+  assert.ok(!!model);
+});
+
+test('implements copyable', function (assert) {
+  assert.expect(0);
+
+  let model = ComplexAttr.create();
+
+  copy(model);
+});

--- a/tests/unit/models/models/complex-attrs/complex-attr-test.js
+++ b/tests/unit/models/models/complex-attrs/complex-attr-test.js
@@ -88,7 +88,7 @@ test('implements copyable (deep)', function (assert) {
 });
 
 test('copies in array (shallow)', function (assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   const array = [SomeComplexAttr.create({
     foo: 'abc'
@@ -98,10 +98,11 @@ test('copies in array (shallow)', function (assert) {
 
   assert.notEqual(array, arrayCopy, 'should be new array');
   assert.equal(A(array).get('firstObject'), A(arrayCopy).get('firstObject'), 'should be same instance still');
+  assert.equal(array[0].get('id'), arrayCopy[0].get('id'), 'id should be the same (since this is a shallow array copy');
 });
 
 test('copies in array (deep)', function (assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   const array = [SomeComplexAttr.create({
     foo: 'abc'
@@ -113,4 +114,5 @@ test('copies in array (deep)', function (assert) {
   assert.notEqual(A(array).get('firstObject'), A(arrayCopy).get('firstObject'), 'should be a new instance');
 
   assert.equal(array[0].get('foo'), arrayCopy[0].get('foo'), 'foo property should have been copied');
+  assert.notEqual(array[0].get('id'), arrayCopy[0].get('id'), 'id should not be copied');
 });


### PR DESCRIPTION
Makes the base complex-attr object copyable (deep and shallow). You can now call copy directly on a ```complex-attr-{object,array}```. Be sure to pass true into the copy method!  

Only attrs are copied, no adhoc properties (do we want to try and copy other properties?)
Complex-attr ids are not copied. Each copy is a brand new instance with its own id etc.

```javascript
model.get('someComplexAttrArray').copy(true); // get a deep copy of a complex-attr-array
copy(model.get('someComplexAttrArray'), true); // get a deep copy of a complex-attr-array

model.get('someComplexAttrArray').copy(); // get a shallow copy of a complex-attr-array
copy(model.get('someComplexAttrArray')); // get a shallow copy of a complex-attr-array

model.get('someComplexObject').copy(true); // get a deep copy of a complex-attr-object
copy(model.get('someComplexObject'), true); // get a deep copy of a complex-attr-object

model.get('someComplexObject').copy(); // get a shallow copy of a complex-attr-object
copy(model.get('someComplexObject')); // get a shallow copy of a complex-attr-object
```