### PR TITLE
Adjust such that complex-attrs are not created via factory

### DIFF
--- a/addon/transforms/complex-attr-array.js
+++ b/addon/transforms/complex-attr-array.js
@@ -11,12 +11,11 @@ export default ComplexAttrTransform.extend({
       return A();
     }
 
-    const ComplexAttrFactory = this.factoryForType(type);
     const ComplexAttrRegistration = this.registrationForType(type);
     const attributeMetadata = ComplexAttrRegistration.attributesMetadata();
 
     return A(serialized.map((attributes) => {
-      return ComplexAttrFactory.create(this.deserializeAttributes(attributeMetadata, attributes));
+      return ComplexAttrRegistration.create(this.deserializeAttributes(attributeMetadata, attributes));
     }));
   },
 

--- a/addon/transforms/complex-attr-object.js
+++ b/addon/transforms/complex-attr-object.js
@@ -11,10 +11,9 @@ export default ComplexAttrTransform.extend({
       return;
     }
 
-    const ComplexAttrFactory = this.factoryForType(type);
     const ComplexAttrRegistration = this.registrationForType(type);
 
-    return ComplexAttrFactory.create(this.deserializeAttributes(ComplexAttrRegistration.attributesMetadata(), serialized));
+    return ComplexAttrRegistration.create(this.deserializeAttributes(ComplexAttrRegistration.attributesMetadata(), serialized));
   },
 
   /**


### PR DESCRIPTION
Update such that complex-attrs are not created using a factory. 
Reasoning is that we cannot currently guarantee that all 
instances would be created in this way, since we do not have access
to a formal layer (like the store) for their creation. In addition to that
even if we did have factoryFor it means it would be up to us
to ensure that all instances that are created this way are 
destroyed (the container does not track and automatically 
destroy such instances, which means that memory leaks are
possible/imminent). 